### PR TITLE
Don’t import from React internals.

### DIFF
--- a/lib/ReactJsonSchema.js
+++ b/lib/ReactJsonSchema.js
@@ -1,5 +1,4 @@
-import { createElement } from 'react';
-import ReactDOMFactories from 'react/lib/ReactDOMFactories';
+import { DOM, createElement } from 'react';
 
 let _componentMap = null;
 
@@ -41,7 +40,7 @@ export default class ReactJsonSchema {
         Component = schema.component;
       } else if (_componentMap && _componentMap[schema.component]) {
         Component = _componentMap[schema.component];
-      } else if (ReactDOMFactories.hasOwnProperty(schema.component)) {
+      } else if (DOM.hasOwnProperty(schema.component)) {
         Component = schema.component;
       }
     } else {


### PR DESCRIPTION
ReactDOMFactories are exposed as `React.DOM`. Requiring from react/lib/* is not supported.