### PR TITLE
Moving react as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lib",
     "dist"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "react": "^15.3.0"
   },
   "devDependencies": {
@@ -64,6 +64,7 @@
     "react-dom": "^15.3.0",
     "uglify-js": "^2.7.0",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0"
+    "webpack-dev-server": "^1.12.0",
+    "react": "^15.3.0"
   }
 }


### PR DESCRIPTION
- Currently we have `react 15.x.x` as a hard dependency in `react-json-schema`.
- If consumers of `react-json-schema` are still on `0.14.x`, this means we will now have two versions of react in our final bundle.
- To avoid this, this PR sets `react 15.x.x` as a peer dependency. This way applications consuming `react-json-schema` can gradually migrate to `react 15.x.x` and still use `react-json-schema` with no side effects on bundle size

Please let me know if this is a viable solution //cc @elliottisonfire @iamdustan @chaseadamsio