### PR TITLE
Support strings as children

### DIFF
--- a/lib/ReactJsonSchema.js
+++ b/lib/ReactJsonSchema.js
@@ -19,9 +19,13 @@ export default class ReactJsonSchema {
     const Components = [];
     let index = 0;
     for (const subSchema of subSchemas) {
-      subSchema.key = typeof subSchema.key !== 'undefined' ? subSchema.key : index;
-      Components.push(this.parseSchema(subSchema));
-      index++;
+      if (typeof subSchema === 'string') {
+        Components.push(subSchema);
+      } else {
+        subSchema.key = typeof subSchema.key !== 'undefined' ? subSchema.key : index;
+        Components.push(this.parseSchema(subSchema));
+        index++;
+      }
     }
     return Components;
   }


### PR DESCRIPTION
This adds support for translating the following schema into markup like `<p>This paragraph has <a href="http://google.com">a link</a> inside it.</p>`.

```
{
  component: 'p',
  children: [
    'This paragraph has ',
    {
      component: 'a',
      href: 'http://google.com',
      text: 'a link'
    },
    ' inside it'
  ]
}
```

It seems like this kind of thing should definitely be supported since React supports it as seen in [this Babel REPL link](https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=env%2Creact%2Cstage-2&targets=Node-7.4&browsers=%3E%202%25&builtIns=false&debug=false&code_lz=DwBwfAKgFglgzgAhAQwE7IObpFBVmLDJ6oCmAZgLwBEUALnSAFwD0LGA9hxgDakB0AYw4BbamGI8YAOwDWwFsjAIZcGABNSKuvwXggA).

The question it raises is what about the "special" `text` property? Should it be removed or should both formats be supported?

Happy to add tests and stuff if you want to accept this change.